### PR TITLE
Fix message extractor to retain partial data

### DIFF
--- a/SocketCommunicationLib.Tests/SocketMessageStringExtractorTests.cs
+++ b/SocketCommunicationLib.Tests/SocketMessageStringExtractorTests.cs
@@ -103,4 +103,20 @@ public class SocketMessageStringExtractorTests
         actual.Count.ShouldBe(2);
         actual.ShouldBe(new[] { firstMessage, secondMessage });
     }
+
+    [Fact]
+    public void Sut_keep_partial_message_between_calls()
+    {
+        var firstMessage = "First";
+        var secondMessage = "Second";
+        var sut = new SocketMessageStringExtractor(Eom, _encoding);
+
+        var interimList = sut.AppendAndExtract($"{firstMessage}{Eom}{secondMessage}");
+        var finalList = sut.AppendAndExtract(Eom);
+
+        interimList.Count.ShouldBe(1);
+        interimList.ShouldContain(firstMessage);
+        finalList.Count.ShouldBe(1);
+        finalList.ShouldContain(secondMessage);
+    }
 }

--- a/SocketCommunicationLib/SocketMessageStringExtractor.cs
+++ b/SocketCommunicationLib/SocketMessageStringExtractor.cs
@@ -31,30 +31,24 @@ public class SocketMessageStringExtractor
         var data = _stringBuilder.ToString();
         int startIndex = 0;
         int index;
-        int remainStartIndex = 0;
         List<string> list = new();
         while ((index = data.IndexOf(_delimiter, startIndex, StringComparison.Ordinal)) != -1)
         {
-            var msg = data.Substring(startIndex, index - startIndex);
-            msg = msg.Trim();
+            var msg = data.Substring(startIndex, index - startIndex).Trim();
             if (!string.IsNullOrEmpty(msg))
             {
                 list.Add(msg);
             }
-            
+
             startIndex = index + _delimiter.Length;
-            remainStartIndex = startIndex + _delimiter.Length;
-            if (data.Length < remainStartIndex)
-            {
-                break;
-            }
         }
+
         _stringBuilder.Clear();
-        if (data.Length > remainStartIndex)
+        if (startIndex < data.Length)
         {
-            _stringBuilder.Append(
-                data.Substring(remainStartIndex, data.Length - remainStartIndex));
+            _stringBuilder.Append(data.Substring(startIndex));
         }
+
         return list;
     }
 }


### PR DESCRIPTION
## Summary
- Ensure SocketMessageStringExtractor keeps uncompleted message fragments between calls
- Cover scenario with new unit test

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ff209cb548330849a8aefafd7cb65